### PR TITLE
Parse int flexchild property values to fix resizing bug.

### DIFF
--- a/src/components/flexChild.js
+++ b/src/components/flexChild.js
@@ -14,7 +14,7 @@ export default class FlexChild extends Component {
 
   handleChildProps(e) {
     const { value, name, min } = e.target
-    const checkMin = value < min ? min : value;
+    const checkMin = value < min ? parseInt(min) : parseInt(value);
     this.setState({
       [name]: checkMin
     })


### PR DESCRIPTION
Flex child items now resize as expected when changing flex-direction from row to column. @Mickyfen17 @marissa27 